### PR TITLE
Fixes for python3/noetic compatibility

### DIFF
--- a/fadecandy_driver/CMakeLists.txt
+++ b/fadecandy_driver/CMakeLists.txt
@@ -7,7 +7,8 @@ catkin_python_setup()
 
 catkin_package()
 
-install(PROGRAMS
-  scripts/fadecandy_node
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+catkin_install_python(
+    PROGRAMS
+    scripts/fadecandy_node
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )

--- a/fadecandy_driver/package.xml
+++ b/fadecandy_driver/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>diagnostic_updater</exec_depend>
   <exec_depend>fadecandy_msgs</exec_depend>
-  <exec_depend>python-usb</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-usb</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-usb</exec_depend>
   <exec_depend>rospy</exec_depend>
 </package>


### PR DESCRIPTION
Based on comments by @sloretz here: https://github.com/ros/rosdistro/pull/25171

Tested on melodic. May need further changes after the rosdep rule for python3-usb gets merged.