### PR TITLE
Update fadecandy_driver.cpp

### DIFF
--- a/fadecandy_driver/src/fadecandy_driver.cpp
+++ b/fadecandy_driver/src/fadecandy_driver.cpp
@@ -55,6 +55,7 @@ FadecandyDriver::FadecandyDriver()
 
 FadecandyDriver::~FadecandyDriver()
 {
+  releaseInterface(); 
   libusb_exit(context_);
 }
 


### PR DESCRIPTION
Release interface before libusb_exit.